### PR TITLE
fix(v2-readme): example using deprecated version number fixed

### DIFF
--- a/schema/2.0/README.md
+++ b/schema/2.0/README.md
@@ -159,7 +159,7 @@ you add as many references as you want for your application:
 ###### Full Example
 
 > ```yaml
-> version: 1.1
+> version: 2.0
 > about:
 >   id: awesome-2018
 >   title: My Awesome App


### PR DESCRIPTION
Because lazy developers will continue to copy paste the example `colophon.yml` as a template ... without realizing the version in the `README.md` has been deprecated. **_Whoops!_**